### PR TITLE
fix: wrong renderer used due to memoization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
-## 0.5 (2024-02-16)
+## 0.5 (2024-03-13)
 
 * Improve performance in `two_columns` via the zipper data structure 
   and caching.
+* Fix a bug caused from a wrong renderer is used due to memoization.
+  Thanks to @zbyrn who reported the issue (#2)!
 
 ## 0.4 (2024-02-14)
 

--- a/test/main.ml
+++ b/test/main.ml
@@ -371,6 +371,22 @@ let test_two_columns_performance () =
      |> ignore;
      true)
 
+let test_different_renderer () =
+  let w = 20 in
+  let cf = Printer.default_cost_factory ~page_width:w () in
+  let module P = Printer.Make (val cf) in
+  let open P in
+
+  let d = text "while (true) {" ^^
+          nest 4
+            (nl ^^ text "f();" ^^ nl ^^ text "if (done())" ^^
+             (let exit_d = text "exit();" in
+              (space ^^ exit_d) <|> nest 4 (nl ^^ exit_d))) ^^
+          nl ^^ text "}"
+  in
+  Alcotest.(check string) "same string" vert_layout (pretty_format d);
+  Alcotest.(check string) "same string" vert_layout (pretty_format d)
+
 let () =
   Alcotest.run "pretty expressive"
     [ "example doc",
@@ -391,4 +407,7 @@ let () =
         "regression phantom space", `Quick, test_two_columns_regression_phantom;
         "cost factory - overflow", `Quick, test_two_columns_factory_overflow;
         "cost factory - bias", `Quick, test_two_columns_factory_bias;
-        "performance", `Slow, test_two_columns_performance ] ]
+        "performance", `Slow, test_two_columns_performance ];
+
+      "regression test",
+      [ "different renderer (issue #2)", `Quick, test_different_renderer ] ]


### PR DESCRIPTION
When a document is printed multiple times, memoization is reused, as intended. However, these printing could be done with different renderers. Prior this commit, the memoization also remembers the renderer that was used. Therefore, subsequent printing could use a stale, memoized renderer. This commit fixes the issue by threading the renderer through the layout function, so that it becomes "stateless" and can be memoized with no stale state saving.

Fixes #2