### PR TITLE
tool: add an upper bound to avoid the breaking change in MDX

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,5 +25,5 @@
  (description "A pretty printer implementation of 'A Pretty Expressive Printer' (OOPSLA'23), with an emphasis on expressiveness and optimality.")
  (depends (ocaml (>= 4.05))
           dune
-          (mdx      (and (>= 2.3.0) :with-test))
+          (mdx      (and (>= 2.3.0) (<= 2.3.1) :with-test))
           (alcotest :with-test)))

--- a/pretty_expressive.opam
+++ b/pretty_expressive.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/sorawee/pretty-expressive-ocaml/issues"
 depends: [
   "ocaml" {>= "4.05"}
   "dune" {>= "3.10"}
-  "mdx" {>= "2.3.0" & with-test}
+  "mdx" {>= "2.3.0" & <= "2.3.1" & with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
https://github.com/realworldocaml/mdx/pull/446 adds an ability to run included blocks. Our included block is not meant to be run, however, and it appears that there's no easy way to skip the running. So as a temporary workaround, we set the upper bound on the MDX version until a satisfactory solution emerges.